### PR TITLE
Ensure we preserve the state of user/drives across restarts

### DIFF
--- a/src/bdos_drive.rs
+++ b/src/bdos_drive.rs
@@ -1,5 +1,6 @@
 use super::bdos_environment::*;
 use super::constants::*;
+use iz80::Machine;
 
 pub fn select(env: &mut BdosEnvironment, selected: u8) {
     // The Select Disk function designates the disk drive named in register E as
@@ -15,6 +16,10 @@ pub fn select(env: &mut BdosEnvironment, selected: u8) {
     // directly reference drives A through P.
     env.state.drive = selected & 0x0f;
     env.state.selected_bitmap |= 1 << env.state.drive;
+
+
+    // Update the RAM bye to mark our drive/user in a persistent way.
+    env.machine.poke(CCP_USER_DRIVE_ADDRESS, env.state.user << 4 | env.state.drive)
 }
 
 pub fn get_current(env: &BdosEnvironment) -> u8 {
@@ -33,7 +38,7 @@ pub fn get_log_in_vector(env: &BdosEnvironment) -> u16 {
     // or an implicit drive select caused by a file operation that specified a
     // nonzero dr field. The user should note that compatibility is maintained
     // with earlier releases, because registers A and L contain the same values
-    // upon return. 
+    // upon return.
     env.state.selected_bitmap
 }
 
@@ -51,7 +56,7 @@ pub fn get_read_only_vector(env: &BdosEnvironment) -> u16 {
     // least significant bit corresponds to drive A, while the most significant
     // bit corresponds to drive P. The R/O bit is set either by an explicit call
     // to Function 28 or by the automatic software mechanisms within CP/M that
-    // detect changed disks. 
+    // detect changed disks.
     env.state.read_only_bitmap
 }
 
@@ -64,7 +69,7 @@ pub fn get_disk_allocation_vector(_env: &BdosEnvironment) -> u16 {
     // information might be invalid if the selected disk has been marked
     // Read-Only. Although this function is not normally used by application
     // programs, additional details of the allocation vector are found in
-    // Section 6. 
+    // Section 6.
     BDOS_ALVEC0_ADDRESS
 }
 

--- a/src/bdos_drive.rs
+++ b/src/bdos_drive.rs
@@ -18,7 +18,7 @@ pub fn select(env: &mut BdosEnvironment, selected: u8) {
     env.state.selected_bitmap |= 1 << env.state.drive;
 
 
-    // Update the RAM bye to mark our drive/user in a persistent way.
+    // Update the RAM byte to mark our drive/user in a persistent way.
     env.machine.poke(CCP_USER_DRIVE_ADDRESS, env.state.user << 4 | env.state.drive)
 }
 

--- a/src/bdos_environment.rs
+++ b/src/bdos_environment.rs
@@ -46,8 +46,6 @@ impl BdosState {
     }
 
     pub fn reset(&mut self) {
-        self.user = 0;
-        self.drive = 0;
         self.selected_bitmap = 1<<0;
         self.read_only_bitmap = 0;
         self.dma =  DEFAULT_DMA;
@@ -77,7 +75,7 @@ impl <'a> BdosEnvironment<'_> {
         self.machine.peek(IOBYTE_ADDRESS) & 0x0f
     }
     pub fn set_iobyte(&mut self, iobyte: u8) {
-        self.machine.poke(IOBYTE_ADDRESS, iobyte); 
+        self.machine.poke(IOBYTE_ADDRESS, iobyte);
     }
 
     pub fn load_buffer(&mut self) {

--- a/src/bdos_file.rs
+++ b/src/bdos_file.rs
@@ -363,7 +363,7 @@ pub fn get_set_user_number(env: &mut BdosEnvironment, user: u8) -> u8 {
     if user != 0xff {
         env.state.user = user & 0x0f;
 
-        // Update the RAM bye to mark our drive/user in a persistent way.
+        // Update the RAM byte to mark our drive/user in a persistent way.
         env.machine.poke(CCP_USER_DRIVE_ADDRESS, env.state.user << 4 | env.state.drive)
 
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,7 @@ fn main() {
         .arg(Arg::with_name("ccp")
             .long("ccp")
             .value_name("ccp")
-            .help("Alternative CPP bynary, it must be compiled with CCP_BASE=$f000"))
+            .help("Alternative CPP binary, it must be compiled with CCP_BASE=$f000"))
         .arg(Arg::with_name("disk_a").long("disk-a").value_name("path").short("a").default_value(".").help("directory to map disk A:"))
         .arg(Arg::with_name("disk_b").long("disk-b").value_name("path").short("b").help("directory to map disk B:"))
         .arg(Arg::with_name("disk_c").long("disk-c").value_name("path").short("c").help("directory to map disk C:"))
@@ -123,7 +123,7 @@ fn main() {
         Some("adm3a") => Box::new(Adm3aToAnsi::new()),
         Some("ansi") => Box::new(Transparent::new()),
         _ => {
-            eprintln!("Unkown terminal emulattion. Choose \"adm3a\" or \"ansi\".");
+            eprintln!("Unkown terminal emulation. Choose \"adm3a\" or \"ansi\".");
             return;
         }
     };
@@ -219,7 +219,7 @@ fn main() {
     if !use_tpa {
         // Upon entry to a transient program, the CCP leaves the stack pointer
         // set to an eight-level stack area with the CCP return address pushed
-        // onto the stack, leaving seven levels before overflow occurs. 
+        // onto the stack, leaving seven levels before overflow occurs.
         if binary_address == TPA_BASE_ADDRESS {
             let mut sp = TPA_STACK_ADDRESS;
             // Push 0x0000
@@ -235,7 +235,7 @@ fn main() {
         // the operator following the program name. The first position contains
         // the number of characters, with the characters themselves following
         // the character count. The characters are translated to upper-case
-        // ASCII with uninitialized memory following the last valid character. 
+        // ASCII with uninitialized memory following the last valid character.
         Fcb::new(FCB1_ADDRESS).set_name_direct(&mut machine, "        .   ".to_string());
         Fcb::new(FCB2_ADDRESS).set_name_direct(&mut machine, "        .   ".to_string());
         match params {
@@ -306,7 +306,7 @@ fn main() {
             er = bdos.execute(&mut bios, &mut machine, cpu.registers(),
                 call_trace || call_trace_all, call_trace && ! call_trace_all);
         }
-    
+
         match er {
             ExecutionResult::Continue => (),
             ExecutionResult::Stop => {
@@ -346,13 +346,14 @@ fn main() {
                         machine.poke(binary_address + i as u16, binary[i]);
                     }
                     cpu.registers().set_pc(binary_address);
-                    cpu.registers().set8(Reg8::C, 0); // Reset user and drive
+                    let user_drive = machine.peek(CCP_USER_DRIVE_ADDRESS);
+                    cpu.registers().set8(Reg8::C, user_drive);
                     bdos.reset(&mut machine); // Reset Bdos
                 } else {
                     break;
                 }
             }
-            
+
 
         }
 


### PR DESCRIPTION
This will close #13, by preserving the current user-number, and selected drive across restarts.

This is only visible when using non-default drives, but it really does help avoid needing to reset drives when running short-lived binaries.

(User-numbers are a waste of time, and nobody uses them, but for completeness I've updated to preserve those too.)