### PR TITLE
Fixed off-by-one in handling of drive P: in CLI args.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -135,7 +135,7 @@ fn main() {
     bdos.reset(&mut machine);
 
     // Assign drives
-    for i in 0..15 {
+    for i in 0..16 {
         let res = matches.value_of(format!("disk_{}", (i + b'a') as char));
         if let Some(path) = res {
             if let Err(err) = fs::read_dir(path) {


### PR DESCRIPTION
The command-line interface allows the specification of local directories to be used as CP/M drives.

I accidentally noticed that the final drive is not specified as expected because I happen to have a P-drive setup for Turbo-Pascal:

```
$ ./target/debug/iz-cpm --disk-p /home/skx/Repos/github.com/skx/cpm-dist/P
iz-cpm https://github.com/ivanizag/iz-cpm
CP/M 2.2 Emulation
Press ctrl-c ctrl-c Y to return to host

A>p:
P>dir
Bdos Err On P: Bad Sector

No File
```

There is a loop setup which runs from 0-15, but it excludes the last value.  This PR updates to use 0-16, so that drive 15 (P:) is included.