### PR TITLE
Add a fake handler for BDOS #102 / F_TIMEDATE

### DIFF
--- a/src/bdos.rs
+++ b/src/bdos.rs
@@ -259,6 +259,10 @@ pub fn execute_bdos(bdos: &mut Bdos, bios: &mut Bios, console: &mut dyn ConsoleE
             },
 
 
+            102 => { // F_TIMEDATE - Get file date and time
+                // Not implemented
+                // Ignored silently to run the HiSoft C compilers.
+            },
             105 => { // T_GET - Get date and time
                 // Not implemented
                 // Ignored silently to run https://github.com/sblendorio/gorilla-cpm


### PR DESCRIPTION
The BDOS F_TIMEDATE call is necessary to run old versions of the HI-TECH C compiler, without this we see immediate errors:

```
..
Press ctrl-c ctrl-c Y to return to host

A>C309 E.C -O -LF -DHISOFTC
HI-TECH C COMPILER (CP/M-80) V3.09
Copyright (C) 1984-87 HI-TECH SOFTWARE
BDOS command 102 not implemented.

```