### PR TITLE
Fix random file access and add some CP/M+ BDOS Calls / Return Code Pass-Throuh

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,33 @@
 
 ## This is a fork of iz-cpm from Ivan Izaguirre
 
-This fork adds some CP/M Plus (CP/M 3) compatibility features:
+This fork adds some CP/M Plus (CP/M 3) compatibility features, all guarded by the `--cpm3` flag:
 
 - **`--cpm3` flag**: Reports CP/M version 3.1 via BDOS 12 (S_BDOSVER) instead of 2.2. Required for programs that check the version before using CP/M+ features.
 - **BDOS 44 (F_MULTISEC)**: Multi-sector I/O support. Programs can request multiple 128-byte sectors per F_READ/F_WRITE call. Unfilled sectors on EOF are padded with ctrl-Z as per CP/M convention.
 - **BDOS 108 (P_CODE)**: Program return code. CP/M+ programs can set an exit code that is propagated to the host OS process exit code.
-
 The exit code mapping from the 16-bit P_CODE to the 8-bit host exit code is: `0x0000` → 0, `0x0001`–`0xFEFF` → low byte, `0xFF00`–`0xFFFF` (fatal errors) → low byte if non-zero, else `0xFF`.
+This enables using iz-cpm in Makefiles, with CP/M+ programs reporting success or failure via the return code (BDOS 108 / P_CODE). SLR180 is one example.
 
-This enables using iz-cpm in Makefiles, with CP/M+ programs reporting success or failure via the return code (BDOS 108 / P_CODE).  SLR180 is one example. 
+### File size with byte granularity (LRBC)
+
+CP/M 2.2 file sizes are always a multiple of 128 bytes. CP/M Plus introduces the Last Record Byte Count to express the exact byte size of a file:
+
+- **BDOS 15 (F_OPEN)**: If CR = 0FFH on entry, F_OPEN returns the LRBC in CR instead of zeroing it. `0` means the last record is full (128 bytes); `1`–`127` is the number of bytes used.
+- **BDOS 17/18 (F_SFIRST / F_SNEXT)**: The S1 field (byte 13) of the returned directory entry contains the LRBC, enabling byte-granular file sizes in directory listings.
+- **BDOS 30 (F_ATTRIB)**: Setting the F6' attribute bit and writing a byte count into FCB+32 (CR) truncates the host file to the exact size.
+- **BDOS 35 (F_SIZE)**: Record count is capped at 262144 (r2=4) as per the CP/M 3 specification, instead of 65536 (r2=1) for CP/M 2.2.
+
+### FCB S2/EX/CR fix (applies to both CP/M 2.2 and CP/M 3)
+
+The S2 field of the FCB was'nt read or written in the original iz-cpm, silently limiting sequential file access to ~4 MB before the EX byte overflowed. S2 is now (hopefully?) correctly managed as the highest bits of the extent number, raising the limit to 8 MB for CP/M 2.2 and 32 MB for CP/M 3.
+Also, Read/Write Random didn't update the S2/EX/CR fields. 
+
+This affects all file access paths:
+- **Sequential read/write (BDOS 20/21)**: EX rolls over at 31 and increments S2 instead of wrapping.
+- **Random read/write (BDOS 33/34)**: After positioning via r0/r1/r2, the FCB fields EX, S2 and CR are set, so subsequent sequential access from that position should work as expected.
+- **F_RANDREC (BDOS 36)**: Converts the current sequential position (including S2) back to r0/r1/r2.
+- **F_SIZE (BDOS 35)**: Record count already uses the host file size directly and is not affected.
 
 ## What is this?
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # iz-cpm -- CP/M 2.2 environment
 
+## This is a fork of iz-cpm from Ivan Izaguirre
+
+This fork adds some CP/M Plus (CP/M 3) compatibility features:
+
+- **`--cpm3` flag**: Reports CP/M version 3.1 via BDOS 12 (S_BDOSVER) instead of 2.2. Required for programs that check the version before using CP/M+ features.
+- **BDOS 44 (F_MULTISEC)**: Multi-sector I/O support. Programs can request multiple 128-byte sectors per F_READ/F_WRITE call. Unfilled sectors on EOF are padded with ctrl-Z as per CP/M convention.
+- **BDOS 108 (P_CODE)**: Program return code. CP/M+ programs can set an exit code that is propagated to the host OS process exit code.
+
+The exit code mapping from the 16-bit P_CODE to the 8-bit host exit code is: `0x0000` → 0, `0x0001`–`0xFEFF` → low byte, `0xFF00`–`0xFFFF` (fatal errors) → low byte if non-zero, else `0xFF`.
+
+This enables using iz-cpm in Makefiles, with CP/M+ programs reporting success or failure via the return code (BDOS 108 / P_CODE).  SLR180 is one example. 
+
 ## What is this?
 
 This is a CP/M 2.2 execution environment. It provides everything needed to run a standard CP/M for Z80 or 8080 binary.

--- a/src/bdos.rs
+++ b/src/bdos.rs
@@ -110,7 +110,7 @@ pub fn execute_bdos(bdos: &mut Bdos, bios: &mut Bios, console: &mut dyn ConsoleE
     // We do the BIOS actions outside the emulation.
     let pc = reg.pc();
     if pc == BDOS_BASE_ADDRESS {
-        let env = &mut BdosEnvironment::new(&mut bdos.state, bios, console, machine, call_trace);
+        let env = &mut BdosEnvironment::new(&mut bdos.state, bios, console, machine, call_trace, bdos.cpm3);
         let arg8 = reg.get8(Reg8::E);
         let arg16 = reg.get16(Reg16::DE);
         let command = reg.get8(Reg8::C);
@@ -260,7 +260,7 @@ pub fn execute_bdos(bdos: &mut Bdos, bios: &mut Bios, console: &mut dyn ConsoleE
             40 => { // F_WRITEZ - Write random with zero fill
                 res8 = Some(bdos_file::write_rand_zero_fill(env, arg16));
             },
-            44 => { // F_MULTISEC - Set number of records to read/write at once (CP/M+)
+            44 if env.cpm3 => { // F_MULTISEC - Set number of records to read/write at once (CP/M+)
                 res8 = Some(bdos_file::set_multi_sector_count(env, arg8));
             },
             45 => { // F_ERRMODE - Set action on hardware error
@@ -276,7 +276,7 @@ pub fn execute_bdos(bdos: &mut Bdos, bios: &mut Bios, console: &mut dyn ConsoleE
                 // Not implemented
                 // Ignored silently to run https://github.com/sblendorio/gorilla-cpm
             },
-            108 => { // P_CODE - Get/set program return code (CP/M+)
+            108 if env.cpm3 => { // P_CODE - Get/set program return code (CP/M+)
                 if arg16 == 0xffff {
                     res16 = Some(env.state.p_code.unwrap_or(0));
                 } else {

--- a/src/bdos.rs
+++ b/src/bdos.rs
@@ -9,7 +9,7 @@ use crate::console_emulator::ConsoleEmulator;
 use crate::cpm_machine::CpmMachine;
 use crate::constants::*;
 
-const BDOS_COMMAND_NAMES: [&str; 106] = [
+const BDOS_COMMAND_NAMES: [&str; 109] = [
     // 0
     "P_TERMCPM", "C_READ", "C_WRITE", "A_READ", "A_WRITE",
     "L_WRITE", "C_RAWIO", "A_STATIN", "A_STATOUT", "C_WRITESTR",
@@ -23,29 +23,31 @@ const BDOS_COMMAND_NAMES: [&str; 106] = [
     "F_ATTRIB", "DRV_DPB", "F_USERNUM", "F_READRAND", "F_WRITERAND",
     "F_SIZE", "F_RANDREC", "DRV_RESET", "*", "",
     // 40
-    "F_WRITEZ", "", "", "", "",
+    "F_WRITEZ", "", "", "", "F_MULTISEC",
     "F_ERRMODE", "", "", "", "",
 
     "", "", "", "", "", "", "", "", "", "", // 50-59
     "", "", "", "", "", "", "", "", "", "", // 60-69
     "", "", "", "", "", "", "", "", "", "", // 70-79
     "", "", "", "", "", "", "", "", "", "", // 80-89
-    "", "", "", "", "", "", "", "", "", "", // 00-09
+    "", "", "", "", "", "", "", "", "", "", // 90-99
 
     // 100
     "", "", "", "", "",
-    "T_GET"
+    "T_GET", "", "", "P_CODE",
     ];
 
 pub struct Bdos {
     state: BdosState,
+    pub cpm3: bool,
 }
 
 impl Bdos {
 
-    pub fn new() -> Bdos {
+    pub fn new(cpm3: bool) -> Bdos {
         Bdos {
-            state: BdosState::new()
+            state: BdosState::new(),
+            cpm3,
         }
     }
 
@@ -94,6 +96,10 @@ impl Bdos {
 
     pub fn assign_drive(&mut self, drive: u8, path: String) {
         self.state.directories[(drive & 0x0f) as usize] = Some(path);
+    }
+
+    pub fn p_code(&self) -> Option<u16> {
+        self.state.p_code
     }
 }
 
@@ -173,7 +179,7 @@ pub fn execute_bdos(bdos: &mut Bdos, bios: &mut Bios, console: &mut dyn ConsoleE
                 res8 = Some(bdos_console::status(env));
             },
             12 => { // S_BDOSVER - Return version number
-                res16 = Some(get_version());
+                res16 = Some(get_version(bdos.cpm3));
             },
             13 => { // DRV_ALLRESET - Reset disk system
                 res8 = Some(bdos_drive::all_reset(env));
@@ -254,6 +260,9 @@ pub fn execute_bdos(bdos: &mut Bdos, bios: &mut Bios, console: &mut dyn ConsoleE
             40 => { // F_WRITEZ - Write random with zero fill
                 res8 = Some(bdos_file::write_rand_zero_fill(env, arg16));
             },
+            44 => { // F_MULTISEC - Set number of records to read/write at once (CP/M+)
+                res8 = Some(bdos_file::set_multi_sector_count(env, arg8));
+            },
             45 => { // F_ERRMODE - Set action on hardware error
                 bdos_file::set_error_mode(env, arg8);
             },
@@ -266,6 +275,13 @@ pub fn execute_bdos(bdos: &mut Bdos, bios: &mut Bios, console: &mut dyn ConsoleE
             105 => { // T_GET - Get date and time
                 // Not implemented
                 // Ignored silently to run https://github.com/sblendorio/gorilla-cpm
+            },
+            108 => { // P_CODE - Get/set program return code (CP/M+)
+                if arg16 == 0xffff {
+                    res16 = Some(env.state.p_code.unwrap_or(0));
+                } else {
+                    env.state.p_code = Some(arg16);
+                }
             },
 
             _ => {
@@ -297,16 +313,14 @@ pub fn execute_bdos(bdos: &mut Bdos, bios: &mut Bios, console: &mut dyn ConsoleE
     ExecutionResult::Continue
 }
 
-fn get_version() -> u16 {
+fn get_version(cpm3: bool) -> u16 {
     /*
     Function 12 provides information that allows version independent
     programming. A two-byte value is returned, with H = 00
     designating the CP/M release (H = 01 for MP/M) and L = 00 for all
     releases previous to 2.0. CP/M 2.0 returns a hexadecimal 20 in
     register L, with subsequent version 2 releases in the hexadecimal
-    range 21, 22, through 2F. Using Function 12, for example, the
-    user can write application programs that provide both sequential
-    and random access functions.
+    range 21, 22, through 2F. CP/M Plus returns 0x31 (version 3.1).
     */
-    0x0022 // CP/M 2.2 for Z80
+    if cpm3 { 0x0031 } else { 0x0022 }
 }

--- a/src/bdos_environment.rs
+++ b/src/bdos_environment.rs
@@ -67,7 +67,8 @@ pub struct BdosEnvironment<'a> {
     pub bios: &'a mut Bios,
     pub console: &'a mut dyn ConsoleEmulator,
     pub machine: &'a mut CpmMachine,
-    pub call_trace: bool
+    pub call_trace: bool,
+    pub cpm3: bool
 }
 
 impl <'a> BdosEnvironment<'_> {
@@ -76,8 +77,9 @@ impl <'a> BdosEnvironment<'_> {
             bios: &'a mut Bios,
             console: &'a mut dyn ConsoleEmulator,
             machine: &'a mut CpmMachine,
-            call_trace: bool) -> BdosEnvironment<'a> {
-        BdosEnvironment {state, bios, console, machine, call_trace}
+            call_trace: bool,
+            cpm3: bool) -> BdosEnvironment<'a> {
+        BdosEnvironment {state, bios, console, machine, call_trace, cpm3}
     }
 
     pub fn iobyte(&self) -> u8 {

--- a/src/bdos_environment.rs
+++ b/src/bdos_environment.rs
@@ -25,7 +25,10 @@ pub struct BdosState {
     pub dir_drive: u8,
     pub dir_pattern: String,
     pub dir_pos: u16, // We will hold a global position in a DIR.
-
+    // CP/M+ multi-sector I/O count (BDOS 44 / F_MULTISEC)
+    pub multi_sector_count: u8,
+    // CP/M+ program return code (BDOS 108 / P_CODE)
+    pub p_code: Option<u16>,
 }
 
 impl BdosState {
@@ -41,6 +44,8 @@ impl BdosState {
             dir_drive: 0,
             dir_pattern: "????????.???".to_string(),
             dir_pos: 0,
+            multi_sector_count: 1,
+            p_code: None,
         }
     }
 
@@ -50,6 +55,8 @@ impl BdosState {
         self.dma =  DEFAULT_DMA;
         self.dir_pattern = "????????.???".to_string();
         self.dir_pos = 0;
+        self.multi_sector_count = 1;
+        self.p_code = None;
     }
 }
 

--- a/src/bdos_file.rs
+++ b/src/bdos_file.rs
@@ -230,10 +230,38 @@ pub fn read(env: &mut BdosEnvironment, fcb_address: u16) -> u8 {
     // is read from position cr of the extent, and the cr field is automatically
     // incremented to the next record position. If the cr field overflows, the
     // next logical extent is automatically opened and the cr field is reset to
-    // zero in preparation for the next read operation. The value 00H is
-    // returned in the A register if the read operation was successful, while a
-    // nonzero value is returned if no data exist at the next record position
-    // (for example, end-of-file occurs).
+    // zero in preparation for the next read operation.
+    // In single-sector mode (count=1): returns 0=success, non-zero=error/EOF.
+    // In multi-sector mode (count>1, CP/M+): returns the number of records NOT
+    // transferred, so 0 means all N records were read.
+    let count = env.state.multi_sector_count;
+    let base_dma = env.state.dma;
+    let mut records_read: u8 = 0;
+    for i in 0..count {
+        env.state.dma = base_dma.wrapping_add(i as u16 * RECORD_SIZE as u16);
+        let res = read_one(env, fcb_address);
+        if res != DIRECTORY_CODE {
+            // Fill remaining sectors with ctrl-Z so the caller can use ctrl-Z
+            // as an in-buffer EOF marker (CP/M text file convention).
+            if records_read > 0 {
+                for j in (i + 1)..count {
+                    let fill_addr = base_dma.wrapping_add(j as u16 * RECORD_SIZE as u16);
+                    for k in 0..RECORD_SIZE {
+                        env.machine.poke(fill_addr + k as u16, 0x1a /* ctrl-Z */);
+                    }
+                }
+            }
+            break;
+        }
+        records_read += 1;
+    }
+    env.state.dma = base_dma;
+    // CP/M+ multi-sector: return 0 if at least one sector was transferred
+    // (caller uses ctrl-Z as in-buffer EOF); return count if nothing was read.
+    if records_read > 0 { DIRECTORY_CODE } else { count }
+}
+
+fn read_one(env: &mut BdosEnvironment, fcb_address: u16) -> u8 {
     let mut fcb = Fcb::new(fcb_address);
     let record = fcb.get_sequential_record_number(env);
     if env.call_trace {
@@ -242,7 +270,7 @@ pub fn read(env: &mut BdosEnvironment, fcb_address: u16) -> u8 {
 
     let extent_changed = fcb.inc_current_record(env);
 
-    let mut buffer: Buffer = [0; RECORD_SIZE]; 
+    let mut buffer: Buffer = [0; RECORD_SIZE];
     let res = read_record_in_buffer(env, &fcb, record as u16, &mut buffer).unwrap_or(NO_DATA);
     if res == DIRECTORY_CODE {
         env.store_buffer_to_dma(&buffer);
@@ -276,6 +304,22 @@ pub fn write(env: &mut BdosEnvironment, fcb_address: u16) -> u8 {
     // written records overlay those that already exist in the file. Register A
     // = 00H upon return from a successful write operation, while a nonzero
     // value indicates an unsuccessful write caused by a full disk.
+    let count = env.state.multi_sector_count;
+    let base_dma = env.state.dma;
+    let mut records_written: u8 = 0;
+    for i in 0..count {
+        env.state.dma = base_dma.wrapping_add(i as u16 * RECORD_SIZE as u16);
+        let res = write_one(env, fcb_address);
+        if res != DIRECTORY_CODE {
+            break;
+        }
+        records_written += 1;
+    }
+    env.state.dma = base_dma;
+    count - records_written
+}
+
+fn write_one(env: &mut BdosEnvironment, fcb_address: u16) -> u8 {
     let mut fcb = Fcb::new(fcb_address);
     let record = fcb.get_sequential_record_number(env);
     if env.call_trace {
@@ -420,6 +464,14 @@ pub fn get_set_user_number(env: &mut BdosEnvironment, user: u8) -> u8 {
     }
 
     env.state.user
+}
+
+pub fn set_multi_sector_count(env: &mut BdosEnvironment, count: u8) -> u8 {
+    if count == 0 || count > 127 {
+        return 0xff;
+    }
+    env.state.multi_sector_count = count;
+    0
 }
 
 pub fn set_error_mode(_env: &mut BdosEnvironment, _mode: u8) {

--- a/src/bdos_file.rs
+++ b/src/bdos_file.rs
@@ -388,7 +388,7 @@ pub fn read_rand(env: &mut BdosEnvironment, fcb_address: u16) -> u8 {
     // nonzero under the current 2.0 release. Normally, nonzero return codes can
     // be treated as missing data, with zero return codes indicating operation
     // complete.
-    let fcb = Fcb::new(fcb_address);
+    let mut fcb = Fcb::new(fcb_address);
     let record = fcb.get_random_record_number(env);
     if env.call_trace {
         print!("[Read random record {:x} into {:04x}]", record, env.state.dma);
@@ -396,6 +396,7 @@ pub fn read_rand(env: &mut BdosEnvironment, fcb_address: u16) -> u8 {
     if record > 65535 {
         return 6; //06	seek Past Physical end of disk
     }
+    fcb.set_sequential_record_number(env, record as u16);
     let mut buffer: Buffer = [0; RECORD_SIZE];
     let res = read_record_in_buffer(env, &fcb, record as u16, &mut buffer).unwrap_or(NO_DATA);
     if res == DIRECTORY_CODE {
@@ -423,7 +424,7 @@ pub fn write_rand(env: &mut BdosEnvironment, fcb_address: u16) -> u8 {
     // The error codes returned by a random write are identical to the random
     // read operation with the addition of error code 05, which indicates that a
     // new extent cannot be created as a result of directory overflow.
-    let fcb = Fcb::new(fcb_address);
+    let mut fcb = Fcb::new(fcb_address);
     let record = fcb.get_random_record_number(env);
     if env.call_trace {
         print!("[Write random record {:x} into {:04x}]", record, env.state.dma);
@@ -432,6 +433,7 @@ pub fn write_rand(env: &mut BdosEnvironment, fcb_address: u16) -> u8 {
         return 6; //06	seek Past Physical end of disk
     }
 
+    fcb.set_sequential_record_number(env, record as u16);
     let buffer = env.load_buffer_from_dma();
     write_record_from_buffer(env, &fcb, record as u16, &buffer).unwrap_or(NO_DATA)
 }

--- a/src/bdos_file.rs
+++ b/src/bdos_file.rs
@@ -65,14 +65,24 @@ pub fn open(env: &mut BdosEnvironment, fcb_address: u16) -> u8 {
     if env.call_trace {
         print!("[[Open file {}]]", fcb.get_name_for_log(env));
     }
+    // CP/M+: if the current record field, cr, is set to 0FFH on entry,
+    // Function 15 returns the byte count of the last record of the file in
+    // the cr field instead of zeroing it. A value of 0 means the last record
+    // is fully used (128 bytes), 1-127 means that many bytes are used.
+    let return_last_record_byte_count = env.cpm3 && fcb.get_current_record(env) == 0xff;
     match find_host_files(env, &fcb, false, false) {
         Err(_) => FILE_NOT_FOUND, // Error or file not found
         Ok(paths) => match fs::File::open(&paths[0]) {
             Err(_) => FILE_NOT_FOUND,
-            Ok(os_file) => match os_file_size_records(os_file) {
+            Ok(os_file) => match os_file.metadata() {
                 Err(_) => FILE_NOT_FOUND,
-                Ok(record_count) => {
-                    fcb.init(env, record_count);
+                Ok(metadata) => {
+                    let file_size = metadata.len();
+                    fcb.init(env, bytes_to_records(file_size));
+                    if return_last_record_byte_count {
+                        let last_record_byte_count = (file_size % RECORD_SIZE as u64) as u8;
+                        fcb.set_current_record(env, last_record_byte_count);
+                    }
                     DIRECTORY_CODE
                 }
             }
@@ -133,7 +143,7 @@ fn truncate_if_needed(env: &mut BdosEnvironment, fcb: &Fcb, os_file_name: &OsStr
     if extent_is_full {
         return Ok(()); // No truncation needed and it could not be the last extent.
     }
-    if record_count == fcb_record_count as u32 {
+    if record_count == fcb_record_count {
         return Ok(());
     }
 
@@ -189,7 +199,28 @@ pub fn set_attributes(env: &mut BdosEnvironment, fcb_address: u16) -> u8 {
 
     match find_host_files(env, &fcb, false, true) {
         Err(_) => FILE_NOT_FOUND, // Error or file not found
-        Ok(_) => DIRECTORY_CODE // TODO: Do something with this.
+        Ok(paths) => {
+            if env.cpm3 && fcb.get_f6_flag(env) {
+                // CP/M+: F6' set means the cr field contains the Last Record
+                // Byte Count. Truncate the host file accordingly.
+                // lrbc=0: last record is full (128 bytes), no truncation needed.
+                // lrbc=1..127: that many bytes are used in the last record.
+                let lrbc = fcb.get_current_record(env);
+                if lrbc > 0 {
+                    if let Ok(metadata) = fs::metadata(&paths[0]) {
+                        let current_records = bytes_to_records(metadata.len());
+                        if current_records > 0 {
+                            let new_size = (current_records as u64 - 1) * RECORD_SIZE as u64
+                                + lrbc as u64;
+                            if let Ok(file) = fs::OpenOptions::new().write(true).open(&paths[0]) {
+                                let _ = file.set_len(new_size);
+                            }
+                        }
+                    }
+                }
+            }
+            DIRECTORY_CODE
+        }
     }
 }
 
@@ -268,10 +299,15 @@ fn read_one(env: &mut BdosEnvironment, fcb_address: u16) -> u8 {
         print!("[Read record {:x} into {:04x}]", record, env.state.dma);
     }
 
+    let max_record = if env.cpm3 { 262143 } else { 65535 };
+    if record > max_record {
+        return NO_DATA;
+    }
+
     let extent_changed = fcb.inc_current_record(env);
 
     let mut buffer: Buffer = [0; RECORD_SIZE];
-    let res = read_record_in_buffer(env, &fcb, record as u16, &mut buffer).unwrap_or(NO_DATA);
+    let res = read_record_in_buffer(env, &fcb, record, &mut buffer).unwrap_or(NO_DATA);
     if res == DIRECTORY_CODE {
         env.store_buffer_to_dma(&buffer);
     }
@@ -326,8 +362,13 @@ fn write_one(env: &mut BdosEnvironment, fcb_address: u16) -> u8 {
         print!("[Write record {:x} from {:04x}]", record, env.state.dma);
     }
 
+    let max_record = if env.cpm3 { 262143 } else { 65535 };
+    if record > max_record {
+        return NO_DATA;
+    }
+
     let buffer = env.load_buffer_from_dma();
-    let result = write_record_from_buffer(env, &fcb, record as u16, &buffer).unwrap_or(NO_DATA);
+    let result = write_record_from_buffer(env, &fcb, record, &buffer).unwrap_or(NO_DATA);
 
     fcb.inc_current_record(env);
     match update_record_count(env, &mut fcb) {
@@ -388,17 +429,22 @@ pub fn read_rand(env: &mut BdosEnvironment, fcb_address: u16) -> u8 {
     // nonzero under the current 2.0 release. Normally, nonzero return codes can
     // be treated as missing data, with zero return codes indicating operation
     // complete.
+    // Fork note: we always read r0/r1/r2 as a 24-bit record number. Under CP/M 2.2
+    // the 65535-record limit still causes error 06 for nonzero r2, preserving the
+    // original behaviour. Under --cpm3, r2 may be non-zero for files up to 262143
+    // records (32 MB); set_sequential_record_number then sets EX, S2 and CR correctly.
     let mut fcb = Fcb::new(fcb_address);
     let record = fcb.get_random_record_number(env);
     if env.call_trace {
         print!("[Read random record {:x} into {:04x}]", record, env.state.dma);
     }
-    if record > 65535 {
+    let max_record = if env.cpm3 { 262143 } else { 65535 };
+    if record > max_record {
         return 6; //06	seek Past Physical end of disk
     }
-    fcb.set_sequential_record_number(env, record as u16);
+    fcb.set_sequential_record_number(env, record);
     let mut buffer: Buffer = [0; RECORD_SIZE];
-    let res = read_record_in_buffer(env, &fcb, record as u16, &mut buffer).unwrap_or(NO_DATA);
+    let res = read_record_in_buffer(env, &fcb, record, &mut buffer).unwrap_or(NO_DATA);
     if res == DIRECTORY_CODE {
         env.store_buffer_to_dma(&buffer);
     }
@@ -429,13 +475,14 @@ pub fn write_rand(env: &mut BdosEnvironment, fcb_address: u16) -> u8 {
     if env.call_trace {
         print!("[Write random record {:x} into {:04x}]", record, env.state.dma);
     }
-    if record > 65535 {
+    let max_record = if env.cpm3 { 262143 } else { 65535 };
+    if record > max_record {
         return 6; //06	seek Past Physical end of disk
     }
 
-    fcb.set_sequential_record_number(env, record as u16);
+    fcb.set_sequential_record_number(env, record);
     let buffer = env.load_buffer_from_dma();
-    write_record_from_buffer(env, &fcb, record as u16, &buffer).unwrap_or(NO_DATA)
+    write_record_from_buffer(env, &fcb, record, &buffer).unwrap_or(NO_DATA)
 }
 
 pub fn write_rand_zero_fill(env: &mut BdosEnvironment, fcb_address: u16) -> u8 {
@@ -523,7 +570,7 @@ pub fn set_random_record(env: &mut BdosEnvironment, fcb_address: u16) {
         print!("[[Set pos of {}]]", fcb.get_name_for_log(env));
     }
     let record = fcb.get_sequential_record_number(env);
-    fcb.set_random_record_number(env, record as u32);
+    fcb.set_random_record_number(env, record);
 }
 
 pub fn search_first(env: &mut BdosEnvironment, fcb_address: u16) -> u8 {
@@ -600,11 +647,22 @@ pub fn compute_file_size(env: &mut BdosEnvironment, fcb_address: u16) {
 fn compute_file_size_internal(env: &mut BdosEnvironment, fcb: &Fcb) -> io::Result<u32> {
     let paths = find_host_files(env, fcb, false, false)?;
     let os_file = fs::File::open(&paths[0])?;
-    os_file_size_records(os_file)
+    if env.cpm3 {
+        // CP/M+: maximum is 262144 records; r2=04 signals exactly 262144.
+        let file_size = os_file.metadata()?.len();
+        let record = (file_size + RECORD_SIZE as u64 - 1) / RECORD_SIZE as u64;
+        Ok(record.min(262144) as u32)
+    } else {
+        os_file_size_records(os_file)
+    }
 }
 
 fn os_file_size_records(os_file: fs::File) -> io::Result<u32> {
     let file_size = os_file.metadata()?.len();
+    Ok(bytes_to_records(file_size))
+}
+
+fn bytes_to_records(file_size: u64) -> u32 {
     let mut record = file_size / RECORD_SIZE as u64;
     if file_size % RECORD_SIZE as u64 != 0 {
         // We need integer division rounding up.
@@ -614,7 +672,7 @@ fn os_file_size_records(os_file: fs::File) -> io::Result<u32> {
     if record >= 65536 {
         record = 65536;
     }
-    Ok(record as u32)
+    record as u32
 }
 
 fn find_host_files(env: &mut BdosEnvironment, fcb: &Fcb, wildcard: bool, to_write: bool) -> io::Result<Vec<OsString>> {
@@ -652,7 +710,7 @@ fn create_file(env: &mut BdosEnvironment, fcb: &Fcb) -> io::Result<()> {
     Ok(())
 }
 
-fn read_record_in_buffer(env: &mut BdosEnvironment, fcb: &Fcb, record: u16, buffer: &mut Buffer) -> io::Result<u8> {
+fn read_record_in_buffer(env: &mut BdosEnvironment, fcb: &Fcb, record: u32, buffer: &mut Buffer) -> io::Result<u8> {
     let paths = find_host_files(env, fcb, false, false)?;
     let mut os_file = fs::File::open(&paths[0])?;
 
@@ -671,7 +729,7 @@ fn read_record_in_buffer(env: &mut BdosEnvironment, fcb: &Fcb, record: u16, buff
     Ok(0)
 }
 
-fn write_record_from_buffer(env: &mut BdosEnvironment, fcb: &Fcb, record: u16, buffer: &[u8]) -> io::Result<u8> {
+fn write_record_from_buffer(env: &mut BdosEnvironment, fcb: &Fcb, record: u32, buffer: &[u8]) -> io::Result<u8> {
     let paths = find_host_files(env, fcb, false, true)?;
     let mut os_file = fs::OpenOptions::new().write(true).open(&paths[0])?;
 
@@ -710,7 +768,13 @@ fn search_nth(env: &mut BdosEnvironment) -> io::Result<u8> {
                     // Fits the pattern
                     if i == env.state.dir_pos {
                         // This is the one to show
-                        let buffer = build_directory_entry(cpm_name);
+                        let s1 = if env.cpm3 {
+                            let file_size = file.metadata().map(|m| m.len()).unwrap_or(0);
+                            (file_size % RECORD_SIZE as u64) as u8
+                        } else {
+                            0
+                        };
+                        let buffer = build_directory_entry(cpm_name, s1);
                         env.state.dir_pos += 1;
                         env.store_buffer_to_dma(&buffer);
                         return Ok(DIRECTORY_CODE);
@@ -723,7 +787,7 @@ fn search_nth(env: &mut BdosEnvironment) -> io::Result<u8> {
     Ok(FILE_NOT_FOUND) // No more items
 }
 
-fn build_directory_entry(cpm_name: String) -> Buffer {
+fn build_directory_entry(cpm_name: String, s1: u8) -> Buffer {
     // Some commands return a directory record. It can hold 4 directoy entries,
     // but we only use the first one.
 
@@ -738,6 +802,9 @@ fn build_directory_entry(cpm_name: String) -> Buffer {
     for i in 0..3 {
         buffer[9+i] = 0x7F & bytes[9 + i as usize];
     }
+
+    // S1 field: Last Record Byte Count under CP/M+, otherwise 0
+    buffer[13] = s1;
 
     // This user-number byte serves a second purpose. If this byte is set to a
     // value of 0E5H, CP/M considers that the file directory entry has been

--- a/src/bdos_file.rs
+++ b/src/bdos_file.rs
@@ -202,19 +202,23 @@ pub fn set_attributes(env: &mut BdosEnvironment, fcb_address: u16) -> u8 {
         Ok(paths) => {
             if env.cpm3 && fcb.get_f6_flag(env) {
                 // CP/M+: F6' set means the cr field contains the Last Record
-                // Byte Count. Truncate the host file accordingly.
-                // lrbc=0: last record is full (128 bytes), no truncation needed.
-                // lrbc=1..127: that many bytes are used in the last record.
+                // Byte Count. Adjust the host file size accordingly.
+                // lrbc=0: last record is full; round UP to next 128-byte boundary.
+                // lrbc=1..127: that many bytes are used in the last record; truncate.
                 let lrbc = fcb.get_current_record(env);
-                if lrbc > 0 {
-                    if let Ok(metadata) = fs::metadata(&paths[0]) {
-                        let current_records = bytes_to_records(metadata.len());
-                        if current_records > 0 {
-                            let new_size = (current_records as u64 - 1) * RECORD_SIZE as u64
-                                + lrbc as u64;
-                            if let Ok(file) = fs::OpenOptions::new().write(true).open(&paths[0]) {
-                                let _ = file.set_len(new_size);
-                            }
+                if let Ok(metadata) = fs::metadata(&paths[0]) {
+                    let file_size = metadata.len();
+                    let current_records = bytes_to_records(file_size);
+                    let new_size = if lrbc == 0 {
+                        current_records as u64 * RECORD_SIZE as u64
+                    } else if current_records > 0 {
+                        (current_records as u64 - 1) * RECORD_SIZE as u64 + lrbc as u64
+                    } else {
+                        file_size // 0-byte file with lrbc>0: undefined, leave unchanged
+                    };
+                    if new_size != file_size {
+                        if let Ok(file) = fs::OpenOptions::new().write(true).open(&paths[0]) {
+                            let _ = file.set_len(new_size);
                         }
                     }
                 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -4,6 +4,7 @@ fn main() {
     let mut console = Console::new();
     let exit_code = run(None, &mut console);
     if exit_code != 0 {
+        drop(console);
         std::process::exit(exit_code);
     }
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -2,5 +2,8 @@ use izcpm::{run, Console};
 
 fn main() {
     let mut console = Console::new();
-    run(None, &mut console);
+    let exit_code = run(None, &mut console);
+    if exit_code != 0 {
+        std::process::exit(exit_code);
+    }
 }

--- a/src/fcb.rs
+++ b/src/fcb.rs
@@ -201,6 +201,13 @@ impl Fcb {
         self.set_byte(env, FCB_RANDOM_RECORD_OFFSET + 2, (record >> 16) as u8);
     }
 
+    pub fn set_sequential_record_number(&mut self, env: &mut BdosEnvironment, record: u16) {
+        let extent = (record / EXTENT_SIZE as u16) as u8;
+        let cr = (record % EXTENT_SIZE as u16) as u8;
+        self.set_byte(env, FCB_EXTENT_OFFSET, extent);
+        self.set_byte(env, FCB_CURRENT_RECORD_OFFSET, cr);
+    }
+
     pub fn get_record_count(&self, env: &mut BdosEnvironment) -> (bool, u16) {
         if self.get_byte(env, FCB_RECORD_COUNT_OFFSET) == EXTENT_SIZE {
             (true, EXTENT_SIZE as u16)

--- a/src/fcb.rs
+++ b/src/fcb.rs
@@ -31,11 +31,13 @@ const FCB_EXTENSION_OFFSET: u16 = 9;
 */
 const FCB_EXTENT_OFFSET: u16 = 12;
 /*
-    ex: contains the current extent number, normally set to 00 by the user,
-        but in range 0-31 during file I/O
+    ex: current extent number, 0-31 during file I/O
     s1: reserved for internal system use
-    s2: reserved for internal system use, set to zero on call to OPEN, MAKE, SEARCH
+    s2: reserved for internal system use. The BDOS uses it as the high byte
+        of the extent: record = (s2 * 32 + ex) * 128 + cr
+        (s2 = file_pointer / 524288, ex = (file_pointer % 524288) / 16384)
 */
+const FCB_S2_OFFSET: u16 = 14;
 const FCB_RECORD_COUNT_OFFSET: u16 = 15;
 /*
     rc: record count for extent ex; takes on values from 0-127
@@ -88,13 +90,28 @@ impl Fcb {
         self.set_byte(env, FCB_RECORD_COUNT_OFFSET, first_extent_record_count);
     }
 
+    pub fn get_current_record(&self, env: &mut BdosEnvironment) -> u8 {
+        self.get_byte(env, FCB_CURRENT_RECORD_OFFSET)
+    }
+
+    pub fn set_current_record(&mut self, env: &mut BdosEnvironment, value: u8) {
+        self.set_byte(env, FCB_CURRENT_RECORD_OFFSET, value);
+    }
+
+    pub fn get_f6_flag(&self, env: &mut BdosEnvironment) -> bool {
+        // F6' is bit 7 of the 6th filename character (FCB offset 6)
+        self.get_byte(env, FCB_NAME_OFFSET + 5) & 0x80 != 0
+    }
+
     pub fn update_record_count(&mut self, env: &mut BdosEnvironment, record_count: u32) {
         /*
             The record count must reflect the size of the current extent. For us
             only the final extent can have a record count less than 128.
         */
-        let extent = self.get_byte(env, FCB_EXTENT_OFFSET);
-        if (extent as u32) * (EXTENT_SIZE as u32) < record_count {
+        let s2 = self.get_byte(env, FCB_S2_OFFSET) as u32;
+        let ex = self.get_byte(env, FCB_EXTENT_OFFSET) as u32;
+        let extent = s2 * 32 + ex;
+        if extent * (EXTENT_SIZE as u32) < record_count {
             // We are not at the last extent:
             self.set_byte(env, FCB_RECORD_COUNT_OFFSET, EXTENT_SIZE);
         } else {
@@ -171,17 +188,25 @@ impl Fcb {
         }
     }
 
-    pub fn get_sequential_record_number(&self, env: &mut BdosEnvironment) -> u16 {
-        (EXTENT_SIZE as u16) * (self.get_byte(env, FCB_EXTENT_OFFSET) as u16)
-        + (self.get_byte(env, FCB_CURRENT_RECORD_OFFSET) as u16)
+    pub fn get_sequential_record_number(&self, env: &mut BdosEnvironment) -> u32 {
+        let s2 = self.get_byte(env, FCB_S2_OFFSET) as u32;
+        let ex = self.get_byte(env, FCB_EXTENT_OFFSET) as u32;
+        let cr = self.get_byte(env, FCB_CURRENT_RECORD_OFFSET) as u32;
+        (s2 * 32 + ex) * EXTENT_SIZE as u32 + cr
     }
 
     pub fn inc_current_record(&mut self, env: &mut BdosEnvironment) -> bool {
         let cr = 1 + (self.get_byte(env, FCB_CURRENT_RECORD_OFFSET) % EXTENT_SIZE);
         if cr == EXTENT_SIZE {
             self.set_byte(env, FCB_CURRENT_RECORD_OFFSET, 0);
-            let v = 1 + self.get_byte(env, FCB_EXTENT_OFFSET);
-            self.set_byte(env, FCB_EXTENT_OFFSET, v);
+            let ex = self.get_byte(env, FCB_EXTENT_OFFSET);
+            if ex == 31 {
+                self.set_byte(env, FCB_EXTENT_OFFSET, 0);
+                let s2 = 1 + self.get_byte(env, FCB_S2_OFFSET);
+                self.set_byte(env, FCB_S2_OFFSET, s2);
+            } else {
+                self.set_byte(env, FCB_EXTENT_OFFSET, ex + 1);
+            }
             true // Extent changed
         } else {
             self.set_byte(env, FCB_CURRENT_RECORD_OFFSET, cr);
@@ -201,19 +226,25 @@ impl Fcb {
         self.set_byte(env, FCB_RANDOM_RECORD_OFFSET + 2, (record >> 16) as u8);
     }
 
-    pub fn set_sequential_record_number(&mut self, env: &mut BdosEnvironment, record: u16) {
-        let extent = (record / EXTENT_SIZE as u16) as u8;
-        let cr = (record % EXTENT_SIZE as u16) as u8;
-        self.set_byte(env, FCB_EXTENT_OFFSET, extent);
+    pub fn set_sequential_record_number(&mut self, env: &mut BdosEnvironment, record: u32) {
+        let extent = record / EXTENT_SIZE as u32;
+        let cr = (record % EXTENT_SIZE as u32) as u8;
+        let ex = (extent % 32) as u8;
+        let s2 = (extent / 32) as u8;
+        self.set_byte(env, FCB_EXTENT_OFFSET, ex);
+        self.set_byte(env, FCB_S2_OFFSET, s2);
         self.set_byte(env, FCB_CURRENT_RECORD_OFFSET, cr);
     }
 
-    pub fn get_record_count(&self, env: &mut BdosEnvironment) -> (bool, u16) {
+    pub fn get_record_count(&self, env: &mut BdosEnvironment) -> (bool, u32) {
         if self.get_byte(env, FCB_RECORD_COUNT_OFFSET) == EXTENT_SIZE {
-            (true, EXTENT_SIZE as u16)
+            (true, EXTENT_SIZE as u32)
         } else {
-            let record_count = (EXTENT_SIZE as u16) * (self.get_byte(env, FCB_EXTENT_OFFSET) as u16)
-            + (self.get_byte(env, FCB_RECORD_COUNT_OFFSET) as u16);
+            let s2 = self.get_byte(env, FCB_S2_OFFSET) as u32;
+            let ex = self.get_byte(env, FCB_EXTENT_OFFSET) as u32;
+            let extent = s2 * 32 + ex;
+            let record_count = extent * EXTENT_SIZE as u32
+                + self.get_byte(env, FCB_RECORD_COUNT_OFFSET) as u32;
             (false, record_count)
         }
     }

--- a/src/run.rs
+++ b/src/run.rs
@@ -27,7 +27,7 @@ Press ctrl-c ctrl-c Y to return to host";
 
 static CCP_BINARY: &[u8] = include_bytes!("../third-party/bin/zcpr.bin");
 
-pub fn run<'a>(command_line: Option<Vec<&str>>, console: &mut dyn ConsoleEmulator) {
+pub fn run<'a>(command_line: Option<Vec<&str>>, console: &mut dyn ConsoleEmulator) -> i32 {
     // Parse arguments
     let app = App::new(WELCOME)
     .arg(Arg::with_name("CMD")
@@ -50,6 +50,9 @@ pub fn run<'a>(command_line: Option<Vec<&str>>, console: &mut dyn ConsoleEmulato
         .short("z")
         .long("cpu-trace")
         .help("Traces CPU instructions execution"))
+    .arg(Arg::with_name("cpm3")
+        .long("cpm3")
+        .help("Report CP/M version 3.1 instead of 2.2 (enables some CP/M Plus features)"))
     .arg(Arg::with_name("slow")
         .short("s")
         .long("slow")
@@ -97,7 +100,7 @@ pub fn run<'a>(command_line: Option<Vec<&str>>, console: &mut dyn ConsoleEmulato
         Ok(m) => m,
         Err(e) => {
             eprint!("{}", e);
-            return;
+            return 1;
         }
     };
         
@@ -106,6 +109,7 @@ pub fn run<'a>(command_line: Option<Vec<&str>>, console: &mut dyn ConsoleEmulato
     let cpu_trace = matches.is_present("cpu_trace");
     let call_trace = matches.is_present("call_trace") || matches.is_present("call_trace_all");
     let call_trace_all = matches.is_present("call_trace_all");
+    let cpm3 = matches.is_present("cpm3");
     let slow = matches.is_present("slow");
     let cpu_model = matches.value_of("cpu");
     let terminal = matches.value_of("terminal");
@@ -119,7 +123,7 @@ pub fn run<'a>(command_line: Option<Vec<&str>>, console: &mut dyn ConsoleEmulato
         Some("8080") => Cpu::new_8080(),
         _ => {
             eprintln!("Invalid CPU model. Choose \"z80\" or \"8080\" as the CPU.");
-            return;
+            return 1;
         }
     };
 
@@ -129,7 +133,7 @@ pub fn run<'a>(command_line: Option<Vec<&str>>, console: &mut dyn ConsoleEmulato
         Some("ansi") => Box::new(Transparent::new()),
         _ => {
             eprintln!("Unkown terminal emulation. Choose \"adm3a\" or \"ansi\".");
-            return;
+            return 1;
         }
     };
 /*     let console = match console {
@@ -141,7 +145,7 @@ pub fn run<'a>(command_line: Option<Vec<&str>>, console: &mut dyn ConsoleEmulato
     bios.setup(&mut machine);
 
     // Init BDOS
-    let mut bdos = Bdos::new();
+    let mut bdos = Bdos::new(cpm3);
     bdos.reset(&mut machine);
 
     // Assign drives
@@ -150,7 +154,7 @@ pub fn run<'a>(command_line: Option<Vec<&str>>, console: &mut dyn ConsoleEmulato
         if let Some(path) = res {
             if let Err(err) = fs::read_dir(path) {
                 eprintln!("Error with directory \"{}\": {}", path, err);
-                return;
+                return 1;
             }
             bdos.assign_drive(i, path.to_string());
         }
@@ -173,13 +177,13 @@ pub fn run<'a>(command_line: Option<Vec<&str>>, console: &mut dyn ConsoleEmulato
                     match File::open(name) {
                         Err(err) => {
                             eprintln!("Error opening ccp \"{}\": {}", name, err);
-                            return; //process::exit(1);
+                            return 1; //process::exit(1);
                         },
                         Ok(mut file) => {
                             match file.read(&mut buf) {
                                 Err(err) => {
                                     eprintln!("Error loading ccp \"{}\": {}", name, err);
-                                    return; //process::exit(1);
+                                    return 1; //process::exit(1);
                                 },
                                 Ok(size) => {
                                     binary_size = size;
@@ -202,13 +206,13 @@ pub fn run<'a>(command_line: Option<Vec<&str>>, console: &mut dyn ConsoleEmulato
             match File::open(name) {
                 Err(err) => {
                     eprintln!("Error opening \"{}\": {}", name, err);
-                    return; //process::exit(1);
+                    return 1; //process::exit(1);
                 },
                 Ok(mut file) => {
                     match file.read(&mut buf) {
                         Err(err) => {
                             eprintln!("Error loading \"{}\": {}", name, err);
-                            return; //process::exit(1);
+                            return 1; //process::exit(1);
                         },
                         Ok(size) => {
                             binary = &buf;
@@ -375,6 +379,16 @@ pub fn run<'a>(command_line: Option<Vec<&str>>, console: &mut dyn ConsoleEmulato
                 thread::sleep(Duration::from_nanos(1000));
                 n = 0;
             }
+        }
+    }
+
+    match bdos.p_code() {
+        None | Some(0) => 0,
+        Some(c) if c < 0xFF00 => (c & 0xFF) as i32,
+        Some(c) => {
+            // Fatal/special error range (0xFF00-0xFFFF): always non-zero
+            let lo = c & 0xFF;
+            if lo != 0 { lo as i32 } else { 0xFF }
         }
     }
 }


### PR DESCRIPTION
This PR fixes a bug in random read/write record BDOS functions. 
`read_rand` and `write_rand` now update the FCB's current extent and record after each operation, as required by the CP/M 2.2 Interface Guide. Without this, sequential access after random access operates on stale positions, and `truncate_if_needed` on close possibly corrupts the file. This fixes e.g. GENCPM producing invalid CPM3.SYS images with iz-cpm.

It also adds some CP/M+ Features: 
- BDOS 44 (F_MULTISEC): Multi-sector I/O support
- BDOS 108 (P_CODE): Program return code, propagated as the host process exit code. This allows using CP/M+ tools like the SLR80 Assembler inside a Makefile and stopping the build on errors.
- `--cpm3` flag: BDOS Function 12 (S_BDOSVER) Reports OS version 31 instead of 22.  

These additions were made specifically for the SLR80/180 Assembler. SLR checks the OS version before using any CP/M+ function calls and then uses exactly the two functions above on top of the standard CP/M 2.2 calls. The --cpm3 flag may therefore cause confusion, as these changes certainly don't constitute a complete CP/M+ implementation. Other software that sees version 31 reported may exhibit unexpected behavior if it relies on CP/M+ functions that aren't implemented (yet). As of now, i don't know of other software, that supports setting return codes. 
So maybe, this is just too specific for main iz-cpm? 